### PR TITLE
Alpine 3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.5
-MAINTAINER Nicolas Degory <ndegory@axway.com>
 
 RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-    echo "@community http://nl.alpinelinux.org/alpine/v3.5/community" >> /etc/apk/repositories
+    echo "@community http://nl.alpinelinux.org/alpine/v3.5/community" >> /etc/apk/repositories && \
+    echo "@edgecommunity http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
 RUN apk update && \
     apk upgrade && \

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ The edge/main and edge/testing repositories are available for package installati
 - 3.3, 3.3.1
 - 3.4, 3.4.2
 - 20160928 (3.4)
-- 3.5, 3.5.1, latest
+- 3.5, `3.5.2`, latest


### PR DESCRIPTION
- Up to date packages in base image
- Remove maintainer line,
- Add edge community for package pinning

Tested by the docker compose sut service on Docker Hub automated builds.